### PR TITLE
Fix syscall implicit declaration

### DIFF
--- a/src/os_abstraction.h
+++ b/src/os_abstraction.h
@@ -5,6 +5,10 @@
 #ifndef _OS_ABSTRACTION_H
 #define _OS_ABSTRACTION_H
 
+#if defined __APPLE__ || defined __linux__
+	#define _GNU_SOURCE
+#endif
+
 #include <stddef.h>
 #include <stdint.h>
 


### PR DESCRIPTION
`syscall()` requires `_GNU_SOURCE` macro according to the [documentation](http://man7.org/linux/man-pages/man2/syscall.2.html).

Clang throws these warnings as well:
```
warning: implicit declaration of function 'syscall' is invalid in C99 [-Wimplicit-function-declaration]
    return syscall(__NR_gettid);
           ^

warning: this function declaration is not a prototype [-Wstrict-prototypes]
```